### PR TITLE
Add workflow to deploy Blazor app to Azure Web App

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Deploy Blazor Server app
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  AZURE_WEBAPP_NAME: your-azure-webapp-name
+  DOTNET_VERSION: '9.0.x'
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore bgk.sln
+
+      - name: Build
+        run: dotnet build bgk.sln --configuration Release --no-restore
+
+      - name: Publish
+        run: dotnet publish bgk.csproj --configuration Release --output ${{ github.workspace }}/publish --no-restore
+
+      - name: Upload publish artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: blazor-server-app
+          path: ${{ github.workspace }}/publish
+
+  deploy:
+    name: Deploy to Azure Web App
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: production
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: blazor-server-app
+          path: ./publish
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          package: ./publish


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and publish the Blazor Server app with .NET 9
- deploy the published output to the configured Azure Web App using the stored credentials

## Testing
- not run (workflow configuration change)

------
https://chatgpt.com/codex/tasks/task_b_68d6be3c4ac08330a25382a503b29c86