### PR TITLE
Replace hero slideshow with MudBlazor carousel

### DIFF
--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,18 +1,38 @@
 @page "/"
-@implements IDisposable
-@inject IJSRuntime JSRuntime
+@inject IWebHostEnvironment WebHostEnvironment
 
 <PageTitle>Køreskole Odense - Blangstedgaard Køreskole | Kørekort</PageTitle>
 
 <!-- Hero Section with Slideshow -->
 <section class="hero-section">
     <div class="slideshow-container" id="slideshow">
-        <!-- Slides will be dynamically populated -->
-        @foreach (var (image, index) in slideImages.Select((img, i) => (img, i)))
+        @if (slideImages.Count > 0)
         {
-            <div class="slide @(index == currentSlide ? "active" : "")">
-                <img src="@image" alt="Blangstedgaard Køreskole - Billede @(index + 1)" loading="@(index == 0 ? "eager" : "lazy")" />
-            </div>
+            <MudCarousel Class="hero-carousel"
+                         AutoCycle="true"
+                         AutoCycleTime="@slideInterval"
+                         EnableSwipeGesture="false"
+                         ShowArrows="false"
+                         ShowBullets="false"
+                         Style="height: 100%;">
+                @foreach (var (image, index) in slideImages.Select((img, i) => (img, i)))
+                {
+                    <MudCarouselItem>
+                        <div class="hero-slide">
+                            <img src="@image"
+                                 alt="Blangstedgaard Køreskole - Billede @(index + 1)"
+                                 loading="@(index == 0 ? "eager" : "lazy")"
+                                 draggable="false"
+                                 oncontextmenu="return false;"
+                                 class="hero-slide-image" />
+                        </div>
+                    </MudCarouselItem>
+                }
+            </MudCarousel>
+        }
+        else
+        {
+            <div class="hero-fallback" aria-hidden="true"></div>
         }
 
         <div class="hero-content">
@@ -213,60 +233,25 @@
 </section>
 
 @code {
-    private readonly List<string> slideImages = new()
-    {
-        "/images/slides/20181025_152006-scaled-1-scaled.jpeg",
-        "/images/slides/20181125_213625.jpeg",
-        "/images/slides/20191118_194322-scaled.jpeg",
-        "/images/slides/20200113_152727-scaled-1-scaled.jpeg",
-        "/images/slides/20200223_001606-scaled-1-scaled.jpeg",
-        "/images/slides/20200225_164106-scaled-1-scaled.jpeg",
-        "/images/slides/20200504_114522-scaled-1-scaled.jpeg",
-        "/images/slides/20200505_114217-scaled-1-scaled.jpeg",
-        "/images/slides/6351203e33200.jpeg",
-        "/images/slides/635b0f49e7653.jpeg",
-        "/images/slides/636a74edd232d.jpeg",
-        "/images/slides/636a74edef6b1.jpeg",
-        "/images/slides/636a74edf1910.jpeg",
-        "/images/slides/637256b02efe0.jpeg",
-        "/images/slides/643da453e0656.jpeg",
-        "/images/slides/643da498e6cf6.jpeg",
-        "/images/slides/643da49906423.jpeg",
-        "/images/slides/643fe34878120.jpeg",
-        "/images/slides/643fe34895389.jpeg",
-        "/images/slides/64cfc7af36ceb.jpeg",
-        "/images/slides/64cfc8fb81b12.jpeg",
-        "/images/slides/64cfc94560bf0.jpeg",
-        "/images/slides/64cfc9d8c3ba9.jpeg",
-        "/images/slides/65516a8ebc08e.jpeg",
-        "/images/slides/65b82ad855718-scaled.jpeg",
-        "/images/slides/6677234f0b4a3.jpeg"
-    };
+    private static readonly string[] SupportedSlideExtensions = new[] { ".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp" };
+    private static readonly TimeSpan slideInterval = TimeSpan.FromSeconds(4);
 
-    private int currentSlide = 0;
-    private Timer? slideTimer;
+    private List<string> slideImages = new();
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnInitialized()
     {
-        if (firstRender)
+        var slidesDirectory = Path.Combine(WebHostEnvironment.WebRootPath, "images", "slides");
+
+        if (!Directory.Exists(slidesDirectory))
         {
-            StartSlideshow();
+            return;
         }
-    }
 
-    private void StartSlideshow()
-    {
-        slideTimer = new Timer(NextSlide, null, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(4));
-    }
-
-    private async void NextSlide(object? state)
-    {
-        currentSlide = (currentSlide + 1) % slideImages.Count;
-        await InvokeAsync(StateHasChanged);
-    }
-
-    public void Dispose()
-    {
-        slideTimer?.Dispose();
+        slideImages = Directory
+            .EnumerateFiles(slidesDirectory)
+            .Where(file => SupportedSlideExtensions.Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase))
+            .OrderBy(file => Path.GetFileName(file), StringComparer.OrdinalIgnoreCase)
+            .Select(file => $"/images/slides/{Path.GetFileName(file)}")
+            .ToList();
     }
 }

--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -79,25 +79,43 @@ a:hover, .btn-link:hover {
     box-shadow: 0 8px 32px var(--shadow);
 }
 
-.slide {
+.hero-carousel {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
+    height: 100%;
+    pointer-events: none;
+}
+
+.hero-carousel .mud-carousel-swipe,
+.hero-carousel .mud-carousel-item,
+.hero-carousel .mud-carousel-item > div {
+    height: 100%;
+}
+
+.hero-carousel .mud-carousel-item {
+    display: flex;
+}
+
+.hero-slide {
+    position: relative;
     width: 100%;
     height: 100%;
-    opacity: 0;
-    transition: opacity 1.5s ease-in-out;
 }
 
-.slide.active {
-    opacity: 1;
-}
-
-.slide img {
+.hero-slide-image {
     width: 100%;
     height: 100%;
     object-fit: cover;
     object-position: center;
+    border-radius: 12px;
+    user-select: none;
+}
+
+.hero-fallback {
+    position: absolute;
+    inset: 0;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.55));
 }
 
 .hero-content {
@@ -109,6 +127,7 @@ a:hover, .btn-link:hover {
     color: white;
     padding: 3rem 2rem 2rem;
     text-align: center;
+    z-index: 1;
 }
 
 .hero-title {


### PR DESCRIPTION
## Summary
- replace the home page slideshow with a MudBlazor carousel that auto cycles and blocks manual interaction
- load hero slide images dynamically from `wwwroot/images/slides` with a gradient fallback when no files exist
- adjust hero styles to size the carousel content and prevent pointer or context menu interactions on the background imagery

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6c6d5ea7c8330a49ab089efe0a495